### PR TITLE
Fix Typo in Batch Training Script (train.sh)

### DIFF
--- a/train.sh
+++ b/train.sh
@@ -19,7 +19,7 @@ python -u train.py -s data/ref_nerf/ref_real/sedan --eval --iterations 61000 --l
 python -u train.py -s data/ref_nerf/ref_real/toycar --eval --iterations 61000  --longer_prop_iter 36_000 --use_env_scope --env_scope_center 0.6810 0.8080 4.4550 --env_scope_radius 2.707
 
 
-python -u train.p-s data/nerf_synthetic/lego --eval --iterations 61000 --white_background --densification_interval_when_prop 100
+python -u train.py -s data/nerf_synthetic/lego --eval --iterations 61000 --white_background --densification_interval_when_prop 100
 python -u train.py -s data/nerf_synthetic/drums --eval --iterations 61000 --white_background --densification_interval_when_prop 100
 python -u train.py -s data/nerf_synthetic/ship --eval --iterations 61000 --white_background --densification_interval_when_prop 100
 python -u train.py -s data/nerf_synthetic/hotdog --eval --iterations 61000 --white_background --densification_interval_when_prop 100


### PR DESCRIPTION
This pull request fixes a typo in the python train.py command used to train the model on the lego dataset. The original command incorrectly used -s after train.py. This commit modifies the command to use the correct extension, .py.