### PR TITLE
Prevent AttributeError for tb_writer.add_image in training

### DIFF
--- a/train.py
+++ b/train.py
@@ -238,7 +238,8 @@ def training_report(tb_writer, iteration, Ll1, loss, l1_loss, elapsed, testing_i
 
         env_res = render_env_map(scene.gaussians)
         for env_name in env_res.keys():
-            tb_writer.add_image("#envmap/{}".format(env_name), env_res[env_name], global_step=iteration)
+            if tb_writer:
+                tb_writer.add_image("#envmap/{}".format(env_name), env_res[env_name], global_step=iteration)
         
         for config in validation_configs:
             if config['cameras'] and len(config['cameras']) > 0:


### PR DESCRIPTION
This pull request introduces a check to prevent an AttributeError during training. The error occurs when tb_writer is None, and the code attempts to call add_image on it.

Changes made:

Added a conditional check before calling tb_writer.add_image in the loop iterating over environments:

```
for env_name in env_res.keys():
    if tb_writer:  # Check if tb_writer is not None before using it
        tb_writer.add_image("#envmap/{}".format(env_name), env_res[env_name], global_step=iteration)
```
